### PR TITLE
Show correct default day and change selected tab style

### DIFF
--- a/front/src/App/OpenSpace/schedule/Schedule.js
+++ b/front/src/App/OpenSpace/schedule/Schedule.js
@@ -30,7 +30,7 @@ const Schedule = () => {
   } = useGetOpenSpace();
 
   const sortedDates = dates.sort(compareAsc);
-  const todaysDate = new Date(2024, 9, 2);
+  const todaysDate = new Date();
 
   useEffect(() => {
     const firstActiveIndex = sortedDates.findIndex((element) =>

--- a/front/src/App/OpenSpace/schedule/Schedule.js
+++ b/front/src/App/OpenSpace/schedule/Schedule.js
@@ -30,14 +30,16 @@ const Schedule = () => {
   } = useGetOpenSpace();
 
   const sortedDates = dates.sort(compareAsc);
-  const todaysDate = new Date();
+  const todaysDate = new Date(2024, 9, 2);
 
   useEffect(() => {
     const firstActiveIndex = sortedDates.findIndex((element) =>
       isEqualsDateTime(element, todaysDate)
     );
-    setActiveDateIndex(firstActiveIndex == -1 ? 0 : firstActiveIndex);
-  }, [sortedDates, todaysDate]);
+    if (firstActiveIndex !== -1) {
+      setActiveDateIndex(firstActiveIndex);
+    }
+  }, [sortedDates]);
 
   const slotsSchedule = useSlots();
   const pushToOpenSpace = usePushToOpenSpace(id);
@@ -64,7 +66,22 @@ const Schedule = () => {
       </MainHeader>
       <Tabs activeIndex={activeDateIndex} onActive={setActiveDateIndex}>
         {sortedDates.map((date, index) => (
-          <Tab key={index} title={format(date, 'yyyy-MM-dd')}>
+          <Tab
+            key={index}
+            title={format(date, 'yyyy-MM-dd')}
+            style={
+              activeDateIndex == index
+                ? {
+                    border: '2px solid #7D4CDB',
+                    borderRadius: '5px',
+                    padding: '0.5rem',
+                    backgroundColor: 'white',
+                    cursor: 'default',
+                    textDecoration: 'none',
+                  }
+                : {}
+            }
+          >
             <DateSlots
               talksOf={talksOf}
               sortedSlots={sortTimesByStartTime(slots.filter(byDate(date)))}


### PR DESCRIPTION
reference #227 

- On multi-day conferences, the default tab shows the current conference day.
- Changed selected tab style to make it more visible

<img width="1177" alt="Screenshot 2024-09-30 at 1 12 58 PM" src="https://github.com/user-attachments/assets/cbf5bdea-5278-42f4-91ac-5e2d62b6700f">
