### PR TITLE
Remove closure slot

### DIFF
--- a/front/src/App/EditOpenSpace/DateTab.js
+++ b/front/src/App/EditOpenSpace/DateTab.js
@@ -9,9 +9,9 @@ import { TrashIcon } from '#shared/icons';
 const TALK_SLOT = 'TalkSlot';
 const OTHER_SLOT = 'OtherSlot';
 
-const Slot = ({ color, onRemove, start, text }) => (
+const Slot = ({ color, onRemove, start, text, index }) => (
   <>
-    <HourHeader hour={start} />
+    <HourHeader hour={start} isInitial={index == 0} />
     <Box
       background={{ color, opacity: 'medium' }}
       direction="row"
@@ -34,7 +34,9 @@ Slot.propTypes = {
 };
 
 const CloseSlot = ({ time }) => (
-  <Slot color="accent-1" key={`cierre-${time}`} start={time} text="Cierre" />
+  <React.Fragment key="cierre">
+    <HourHeader hour={time} isFinal />
+  </React.Fragment>
 );
 CloseSlot.propTypes = {
   time: PropTypes.string.isRequired,
@@ -42,7 +44,6 @@ CloseSlot.propTypes = {
 
 export const DateTab = ({ value, addSlot, removeSlot, date }) => {
   const lastEnd = getLastEndFromCollectionOfSlots(value);
-
   return (
     <>
       {value.map(({ type, startTime, description }, i) => (
@@ -52,6 +53,7 @@ export const DateTab = ({ value, addSlot, removeSlot, date }) => {
           start={startTime}
           text={type === TALK_SLOT ? 'Charla' : description}
           onRemove={i === value.length - 1 ? () => removeSlot(date, lastEnd) : null}
+          index={i}
         />
       ))}
       {value.length > 0 && <CloseSlot time={lastEnd} />}

--- a/front/src/App/EditOpenSpace/DateTab.js
+++ b/front/src/App/EditOpenSpace/DateTab.js
@@ -33,15 +33,6 @@ Slot.propTypes = {
   text: PropTypes.string.isRequired,
 };
 
-const CloseSlot = ({ time }) => (
-  <React.Fragment key="cierre">
-    <HourHeader hour={time} isFinal />
-  </React.Fragment>
-);
-CloseSlot.propTypes = {
-  time: PropTypes.string.isRequired,
-};
-
 export const DateTab = ({ value, addSlot, removeSlot, date }) => {
   const lastEnd = getLastEndFromCollectionOfSlots(value);
   return (
@@ -56,7 +47,7 @@ export const DateTab = ({ value, addSlot, removeSlot, date }) => {
           index={i}
         />
       ))}
-      {value.length > 0 && <CloseSlot time={lastEnd} />}
+      {value.length > 0 && <HourHeader hour={lastEnd} isFinal />}
 
       <Box direction="row" margin={{ vertical: 'medium' }} justify="evenly">
         <ButtonNew

--- a/front/src/App/OpenSpace/schedule/DateSlots.js
+++ b/front/src/App/OpenSpace/schedule/DateSlots.js
@@ -10,17 +10,17 @@ export const DateSlots = ({ talksOf, sortedSlots, showSpeakerName }) => {
   return (
     <Box margin={{ bottom: 'medium' }}>
       {[
-        ...sortedSlots.map((slot) => (
+        ...sortedSlots.map((slot, index) => (
           <Slot
             key={slot.id}
             talksOf={talksOf}
             slot={slot}
             showSpeakerName={showSpeakerName}
+            index={index}
           />
         )),
         <React.Fragment key="cierre">
-          <HourHeader hour={numbersToTime(sortedSlots.slice(-1)[0].endTime)} />
-          <OtherSlot description="Cierre" />
+          <HourHeader hour={numbersToTime(sortedSlots.slice(-1)[0].endTime)} isFinal />
         </React.Fragment>,
       ]}
     </Box>

--- a/front/src/App/OpenSpace/schedule/Slot.js
+++ b/front/src/App/OpenSpace/schedule/Slot.js
@@ -5,10 +5,10 @@ import { OtherSlot } from './OtherSlot';
 import { TalkSlot } from './TalkSlot';
 import PropTypes from 'prop-types';
 
-export const Slot = ({ slot, talksOf, showSpeakerName }) => {
+export const Slot = ({ slot, talksOf, showSpeakerName, index }) => {
   return (
     <React.Fragment>
-      <HourHeader hour={numbersToTime(slot.startTime)} />
+      <HourHeader hour={numbersToTime(slot.startTime)} isInitial={index == 0} />
       {!slot.assignable ? (
         <OtherSlot description={slot.description} />
       ) : (

--- a/front/src/shared/HourHeader.js
+++ b/front/src/shared/HourHeader.js
@@ -13,15 +13,17 @@ Dots.propTypes = {
   gridArea: PropTypes.string.isRequired,
 };
 
-const HourHeader = ({ hour }) => (
+const HourHeader = ({ hour, isInitial, isFinal }) => (
   <Grid
     areas={[['left', 'main', 'right']]}
-    columns={['flex', 'xsmall', 'flex']}
+    columns={['flex', isInitial || isFinal ? 'small' : 'xsmall', 'flex']}
     rows={['xxsmall']}
   >
     <Dots gridArea="left" />
     <Box align="center" alignSelf="center" gridArea="main" flex>
       {`${hour} hs`}
+      {isInitial && ` (inicio)`}
+      {isFinal && ` (fin)`}
     </Box>
     <Dots gridArea="right" />
   </Grid>


### PR DESCRIPTION
reference #228 

- Removed closure slot to the schedule and edit pages.
- Added "(inicio)" and "(fin)" to the first and last hour header.

<img width="1326" alt="Screenshot 2024-10-01 at 4 14 46 PM" src="https://github.com/user-attachments/assets/5683d036-ae1b-4e4b-b8a7-ee8cd8920ae4">
<img width="1269" alt="Screenshot 2024-10-01 at 4 15 06 PM" src="https://github.com/user-attachments/assets/a33b99c5-97f8-417f-8a72-52790bd68884">
