### PR TITLE
Change return button route when seeing a Talk detail

### DIFF
--- a/front/src/App/Talk/Talk.js
+++ b/front/src/App/Talk/Talk.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import { useUser } from '#helpers/useAuth';
 import { RedirectToRoot, usePushToEditTalk, usePushToOpenSpace } from '#helpers/routes';
 import { useGetTalk, deleteTalk, createReview } from '#api/os-client';
 import MainHeader from '#shared/MainHeader';
 import Spinner from '#shared/Spinner';
 import { useParams, useLocation } from 'react-router-dom';
-import { ScheduleIcon, EditIcon, DeleteIcon, StarIcon } from '#shared/icons';
+import { EditIcon, DeleteIcon, StarIcon } from '#shared/icons';
 import { Button, Anchor, Text, Box, Layer } from 'grommet';
 import Card from '#shared/Card';
 import { ReviewForm } from './ReviewForm';
@@ -22,6 +23,7 @@ const Talk = () => {
   } = useGetTalk();
   const openSpaceId = useParams().id;
   const pushToOpenSpace = usePushToOpenSpace(openSpaceId);
+  const history = useHistory();
   const speakerName = new URLSearchParams(useLocation().search).get('speakerName');
   const amTheSpeaker = user && speaker && speaker.id === user.id;
   const pushToEditTalk = usePushToEditTalk(id);
@@ -61,7 +63,7 @@ const Talk = () => {
             color="accent-1"
             icon={<Return />}
             label="Principal"
-            onClick={pushToOpenSpace}
+            onClick={() => history.goBack()}
           />
         </MainHeader.Buttons>
       </MainHeader>


### PR DESCRIPTION
reference #230 

- Depending on how you got to the Talk detail, the return button redirects you to the correct previous page


https://github.com/user-attachments/assets/b922b63e-3a31-4b3a-99cd-0f1e1d5ec16d

