### PR TITLE
fix/270-new-relic-agent-tasks - part 2

### DIFF
--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -131,7 +131,7 @@ tasks.register<Copy>("unzipAndSetUpNewrelic") {
   doNotTrackState("disable unzip check")
   dependsOn("downloadNewrelic", "jar", "bootJar",
     "resolveMainClassName", "compileKotlin", "processResources")
-  from(zipTree(file("/newrelic/newrelic-java.zip")))
+  from(zipTree(file("newrelic/newrelic-java.zip")))
   into(rootDir)
   doLast {
     delete("newrelic/newrelic-java.zip")


### PR DESCRIPTION
- make relative unzip dir newrelic folder and not from root