### PR TITLE
Fix tracks chips when titles are too long

### DIFF
--- a/front/src/shared/MainHeader.jsx
+++ b/front/src/shared/MainHeader.jsx
@@ -64,9 +64,9 @@ const Tracks = ({ children, tracks, talks, setSelectedTrack, ...props }) => {
   const talksWithoutTrack = talks && talks.filter((talk) => !talk.track);
 
   return (
-    <Box direction={"row-responsive"} gap={"medium"}>
+    <Box gap={"medium"} direction={"row"} wrap>
       {tracks.map((track, index) => (
-        <Button key={index} color={track.color} textColor={"dark-2"} style={{width: "fit-content"}} onClick={(e) => {
+        <Button key={index} color={track.color} textColor={"dark-2"} style={{width: "fit-content", marginTop: "10px"}} onClick={(e) => {
           scrollToSection(e, track.name)
           setSelectedTrack(track.name)
         }}>
@@ -74,7 +74,7 @@ const Tracks = ({ children, tracks, talks, setSelectedTrack, ...props }) => {
         </Button>
       ))}
       {talks && talksWithoutTrack.length > 0 &&
-        <Button color={"#e4e4e4"} textColor={"dark-2"} style={{width: "fit-content"}} onClick={(e) => {
+        <Button color={"#e4e4e4"} textColor={"dark-2"} style={{width: "fit-content", marginTop: "10px"}} onClick={(e) => {
           scrollToSection(e, TALKS_WITHOUT_TRACKS_TITLE)
           setSelectedTrack(TALKS_WITHOUT_TRACKS_TITLE)
         }}>


### PR DESCRIPTION
Problem:
<img width="1724" alt="Screenshot 2024-12-03 at 2 09 41 PM" src="https://github.com/user-attachments/assets/05d5dade-80fc-4412-8868-8a9ac94641e0">

Solution:
<img width="1792" alt="Screenshot 2024-12-03 at 2 09 14 PM" src="https://github.com/user-attachments/assets/0092fd2a-7f4b-44df-9918-7bfe4530764d">
