### PR TITLE
Feature/359 migrate front jwt

### DIFF
--- a/back/src/main/kotlin/com/sos/smartopenspace/config/filter/LogFilter.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/config/filter/LogFilter.kt
@@ -1,8 +1,10 @@
 package com.sos.smartopenspace.config.filter
 
+import com.sos.smartopenspace.services.impl.JwtService.Companion.TOKEN_PREFIX
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import jakarta.ws.rs.core.HttpHeaders
 import org.slf4j.MDC
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
@@ -20,6 +22,7 @@ class LogFilter : OncePerRequestFilter() {
 
         private const val CTX_REQUEST_ID_KEY = "requestId"
         private const val CTX_REQUEST_SESSION_ID_KEY = "requestSessionId"
+        private const val CTX_REQUEST_CONTAINS_JWT = "requestContainsJwt"
 
         private const val DEFAULT_EMPTY_VALUE = "none"
     }
@@ -36,8 +39,13 @@ class LogFilter : OncePerRequestFilter() {
         val requestSessionId = request.getHeader(REQUEST_ID_SESSION)?.ifBlank { DEFAULT_EMPTY_VALUE }
             ?: DEFAULT_EMPTY_VALUE
 
+        val requestContainsJwt:Boolean = request.getHeader(HttpHeaders.AUTHORIZATION)?.let {
+            it.contains(TOKEN_PREFIX) && it.length > TOKEN_PREFIX.length + 1
+        } ?: false
+
         MDC.put(CTX_REQUEST_ID_KEY, requestId)
         MDC.put(CTX_REQUEST_SESSION_ID_KEY, requestSessionId)
+        MDC.put(CTX_REQUEST_CONTAINS_JWT, requestContainsJwt.toString())
         filterChain.doFilter(request, response)
     }
 

--- a/back/src/main/kotlin/com/sos/smartopenspace/controllers/v1/AuthController.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/controllers/v1/AuthController.kt
@@ -6,6 +6,7 @@ import com.sos.smartopenspace.domain.BadRequestException
 import com.sos.smartopenspace.dto.request.auth.LoginRequestDTO
 import com.sos.smartopenspace.dto.request.auth.RegisterRequestDTO
 import com.sos.smartopenspace.dto.response.auth.AuthResponseDTO
+import com.sos.smartopenspace.dto.response.auth.LogoutResponseDTO
 import com.sos.smartopenspace.dto.response.purge.DeletedSessionsResponseDTO
 import com.sos.smartopenspace.services.AuthServiceI
 import com.sos.smartopenspace.translators.UserTranslator
@@ -36,15 +37,17 @@ class AuthController(
     }
 
     @PostMapping("/logout")
-    fun logout(@RequestHeader(HttpHeaders.AUTHORIZATION) authToken: String) =
-        authService.logout(authToken).also {
-            LOGGER.info("Logout successfully")
+    fun logout(@RequestHeader(HttpHeaders.AUTHORIZATION) authToken: String): LogoutResponseDTO =
+        authService.logout(authToken).let {
+            LOGGER.info("Logout successfully with user_id=$it")
+            LogoutResponseDTO(SUCCESS_LOGOUT_MESSAGE)
         }
 
     @PostMapping("/logout/all")
-    fun logoutAllSessions(@RequestHeader(HttpHeaders.AUTHORIZATION) authToken: String) =
-        authService.logoutAllSessions(authToken).also {
-            LOGGER.info("Logout from all sessions successfully")
+    fun logoutAllSessions(@RequestHeader(HttpHeaders.AUTHORIZATION) authToken: String): LogoutResponseDTO =
+        authService.logoutAllSessions(authToken).let {
+            LOGGER.info("Logout from all sessions successfully user_id=$it")
+            LogoutResponseDTO(SUCCESS_LOGOUT_ALL_MESSAGE)
         }
 
     @PostMapping("/validate/{userId}")
@@ -87,6 +90,9 @@ class AuthController(
         const val FILTER_CREATION_ON_MIN = "2024-01-01T00:00:00Z"
         const val FILTER_CREATION_ON_MAX = "4024-01-01T00:00:00Z"
 
+
+        const val SUCCESS_LOGOUT_MESSAGE = "Sesión cerrada exitosamente"
+        const val SUCCESS_LOGOUT_ALL_MESSAGE = "Sesiones cerradas exitosamente"
 
         private const val INVALID_TIME_DATE_FORMAT_MESSAGE = "Invalid time date format - use '2000-01-01T23:59:59Z'"
         private const val INVALID_DATES_FILTER_MESSAGE = "created_on_to should be after created_on_from"

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Exceptions.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Exceptions.kt
@@ -2,8 +2,12 @@ package com.sos.smartopenspace.domain
 
 open class BadRequestException(message: String?) : RuntimeException(message)
 open class NotFoundException(message: String) : BadRequestException(message)
-open class UnauthorizedException(message: String) : RuntimeException(message)
 open class UnprocessableEntityException(message: String?) : RuntimeException(message)
+/**
+ * It is a RuntimeException. Handles 401 (Unauthorized) http status code in ExceptionHandler.
+ * Semantic should be invalid auth session and client should perform a new login.
+ */
+open class UnauthorizedException(message: String) : RuntimeException(message)
 
 class AlreadyActivedQueuingException : BadRequestException("Encolamiento ya se encuentra activo")
 class AnotherTalkIsEnqueuedException : BadRequestException("Existe otra charla encolada")

--- a/back/src/main/kotlin/com/sos/smartopenspace/dto/response/auth/LogoutResponseDTO.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/dto/response/auth/LogoutResponseDTO.kt
@@ -1,0 +1,6 @@
+package com.sos.smartopenspace.dto.response.auth
+
+data class LogoutResponseDTO(
+    val message: String,
+) {
+}

--- a/back/src/main/kotlin/com/sos/smartopenspace/services/AuthServiceI.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/services/AuthServiceI.kt
@@ -10,11 +10,23 @@ interface AuthServiceI {
 
     fun login(email: String, password: String): AuthSession
 
-    fun logout(tokenHeader: String)
+    /**
+     * @return the user id that was logged out.
+     */
+    fun logout(tokenHeader: String): Long
 
-    fun logoutAllSessions(tokenHeader: String)
+    /**
+     * @return the user id that was logged out.
+     */
+    fun logoutAllSessions(tokenHeader: String): Long
 
+    /**
+     * @return true if the token is valid (signed and not expired) and match token payload user_id with param user_id.
+     */
     fun validateToken(tokenHeader: String, userId: Long): Boolean
 
+    /**
+     * @return size of invalid sessions deleted.
+     */
     fun purgeInvalidSessions(creationDateFrom: Instant, creationDateTo: Instant): Int
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/services/impl/AuthService.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/services/impl/AuthService.kt
@@ -35,7 +35,7 @@ class AuthService(
         return createAuthSession(user)
     }
 
-    override fun logout(tokenHeader: String) {
+    override fun logout(tokenHeader: String): Long {
         val token = jwtService.extractToken(tokenHeader)
         val userId = jwtService.extractUserId(token)
         val authSession = authSessionRepository
@@ -44,9 +44,10 @@ class AuthService(
             authSession.revoke()
             authSessionRepository.save(authSession)
         }
+        return userId
     }
 
-    override fun logoutAllSessions(tokenHeader: String) {
+    override fun logoutAllSessions(tokenHeader: String): Long {
         val token = jwtService.extractToken(tokenHeader)
         val userId = jwtService.extractUserId(token)
         val authSessions = authSessionRepository
@@ -55,6 +56,7 @@ class AuthService(
             authSessions.forEach { it.revoke() }
             authSessionRepository.saveAll(authSessions)
         }
+        return userId
     }
 
     override fun validateToken(tokenHeader: String, userId: Long): Boolean {

--- a/back/src/main/resources/logback-spring.xml
+++ b/back/src/main/resources/logback-spring.xml
@@ -11,7 +11,7 @@
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <Pattern>%date{yyyy-MM-dd HH:mm:ss.SSZ} [LEVEL:%clr(%level)] [THREAD:%clr(%thread){magenta}] [SESSION_ID:%clr(%mdc{requestSessionId:-none}){blue}] [REQUEST_ID:%clr(%mdc{requestId:-none}){blue}] %clr(%logger{3}){cyan}: %msg %ex %n</Pattern>
+                <Pattern>%date{yyyy-MM-dd HH:mm:ss.SSZ} [LEVEL:%clr(%level)] [THREAD:%clr(%thread){magenta}] [SESSION_ID:%clr(%mdc{requestSessionId:-none}){blue}] [REQUEST_ID:%clr(%mdc{requestId:-none}){blue}] [REQUEST_WITH_JWT:%clr(%mdc{requestContainsJwt:-none}){blue}] %clr(%logger{3}){cyan}: %msg %ex %n</Pattern>
             </layout>
         </encoder>
     </appender>

--- a/back/src/test/kotlin/com/sos/smartopenspace/controllers/v1/AuthControllerTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/controllers/v1/AuthControllerTest.kt
@@ -6,10 +6,13 @@ import com.sos.smartopenspace.controllers.v1.AuthController.Companion.FILTER_CRE
 import com.sos.smartopenspace.controllers.v1.AuthController.Companion.FILTER_CREATED_ON_TO_NAME
 import com.sos.smartopenspace.controllers.v1.AuthController.Companion.FILTER_CREATION_ON_MAX
 import com.sos.smartopenspace.controllers.v1.AuthController.Companion.FILTER_CREATION_ON_MIN
+import com.sos.smartopenspace.controllers.v1.AuthController.Companion.SUCCESS_LOGOUT_ALL_MESSAGE
+import com.sos.smartopenspace.controllers.v1.AuthController.Companion.SUCCESS_LOGOUT_MESSAGE
 import com.sos.smartopenspace.domain.AuthSession
 import com.sos.smartopenspace.domain.InvalidTokenException
 import com.sos.smartopenspace.domain.User
 import com.sos.smartopenspace.domain.UserUnauthorizedException
+import com.sos.smartopenspace.dto.response.auth.LogoutResponseDTO
 import com.sos.smartopenspace.dto.response.purge.DeletedSessionsResponseDTO
 import com.sos.smartopenspace.sampler.AuthSessionSampler
 import com.sos.smartopenspace.sampler.UserSampler
@@ -258,7 +261,10 @@ class AuthControllerTest : BaseControllerTest() {
                 .header(HttpHeaders.AUTHORIZATION, tokenWithBearer)
         )
         // THEN
-        httpResponse.andExpect(status().is2xxSuccessful)
+        val bodyRes = httpResponse.andExpect(status().is2xxSuccessful)
+            .andReturn().response.getContentAsString(StandardCharsets.UTF_8)
+        val logoutRes = objectMapper.readValue(bodyRes, LogoutResponseDTO::class.java)
+        assertEquals(SUCCESS_LOGOUT_MESSAGE, logoutRes.message)
 
         val allUserAuthSessions = authSessionRepo.findAllByUserId(authSessionSaved1.user.id)
         val postAuthSession1 = allUserAuthSessions.first { it.id == authSessionSaved1.id }
@@ -340,7 +346,11 @@ class AuthControllerTest : BaseControllerTest() {
                 .header(HttpHeaders.AUTHORIZATION, tokenWithBearer)
         )
         // THEN
-        httpResponse.andExpect(status().is2xxSuccessful)
+        val bodyRes = httpResponse.andExpect(status().is2xxSuccessful)
+            .andReturn().response.getContentAsString(StandardCharsets.UTF_8)
+        val logoutRes = objectMapper.readValue(bodyRes, LogoutResponseDTO::class.java)
+        assertEquals(SUCCESS_LOGOUT_ALL_MESSAGE, logoutRes.message)
+
         val userAuthSessions = authSessionRepo.findAllByUserId(authSessionSaved1.user.id)
 
         assertEquals(2, userAuthSessions.size)

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12,6 +12,7 @@
         "date-fns": "^2.28.0",
         "grommet": "^2.39.0",
         "grommet-icons": "^4.4.0",
+        "jwt-decode": "^4.0.0",
         "logrocket": "^3.0.1",
         "markdown-to-txt": "^2.0.1",
         "pluralize": "^8.0.0",
@@ -5729,6 +5730,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/language-subtag-registry": {

--- a/front/package.json
+++ b/front/package.json
@@ -60,6 +60,7 @@
     "date-fns": "^2.28.0",
     "grommet": "^2.39.0",
     "grommet-icons": "^4.4.0",
+    "jwt-decode": "^4.0.0",
     "logrocket": "^3.0.1",
     "markdown-to-txt": "^2.0.1",
     "pluralize": "^8.0.0",

--- a/front/src/__tests__/helpers/jwt.test.js
+++ b/front/src/__tests__/helpers/jwt.test.js
@@ -1,0 +1,103 @@
+import { describe } from 'vitest';
+import { decodeJWT, getUserPayloadFromJwt } from '#helpers/jwt.js';
+
+describe('GIVEN decodeJWT func', () => {
+
+    test('WHEN apply with valid jwt THEN return decoded jwt payload', () => {
+        
+        const jwtValidCases = [
+            { 
+                jwt: 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjotMTAsInVzZXJfZW1haWwiOiIiLCJ1c2VyX25hbWUiOiIiLCJpYXQiOjE3MzQ5MTI1MzksImV4cCI6MTczNDkxMjgzOX0.83JE_NBcgHka4tk_ROkHMq_t2WP0vw_pyZ6zwswd_ps', 
+                expected: {
+                    exp: 1734912839,
+                    iat: 1734912539,
+                    user_email: "",
+                    user_id: -10,
+                    user_name: "",
+                },
+            },
+            { 
+                jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', 
+                expected: {
+                    iat: 1516239022,
+                    name: "John Doe",
+                    sub: "1234567890",
+                },
+            },
+            { 
+                jwt: 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMTEiLCJ1c2VyX2VtYWlsIjoiYXNkMTIzQGFzZC5jb20iLCJ1c2VyX25hbWUiOiJhc2QxMjMiLCJzdWIiOiJhc2QxMjNAYXNkLmNvbSIsImlhdCI6MTczNDI3Mjk0MCwiZXhwIjoxNzM1NTY4OTQwfQ._9zkQ4VhvkcgriALjX0uJJsIcVT4GfELwxLB-nvTrAs',
+                expected: {
+                    exp: 1735568940,
+                    iat: 1734272940,
+                    sub: "asd123@asd.com",
+                    user_email: "asd123@asd.com",
+                    user_id: "11",
+                    user_name: "asd123",
+                },
+            },
+        ];
+        jwtValidCases.forEach(({ jwt, expected }) => {
+            expect(decodeJWT(jwt)).toStrictEqual(expected);
+        });
+    });
+
+    test('WHEN apply with invalid jwt THEN return default value', () => {
+        
+        const invalidJwtCases = [
+            { jwt: '', def: null, expected: null },
+            { jwt: null, def: '', expected: '' },
+            { jwt: ' ', def: 'random', expected: 'random' },
+            { jwt: 'saf12asffas', def: undefined, expected: null },
+        ];
+        invalidJwtCases.forEach(({ jwt, def, expected }) => {
+            expect(decodeJWT(jwt, def)).toBe(expected);
+        });
+    });
+});
+
+
+describe('GIVEN getUserPayloadFromJwt func', () => {
+
+    test('WHEN apply with valid jwt THEN return user payload', () => {
+        
+        const jwtValidCases = [
+            { 
+                jwt: 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjotMTAsInVzZXJfZW1haWwiOiIiLCJ1c2VyX25hbWUiOiIiLCJpYXQiOjE3MzQ5MTI1MzksImV4cCI6MTczNDkxMjgzOX0.83JE_NBcgHka4tk_ROkHMq_t2WP0vw_pyZ6zwswd_ps', 
+                expected: {
+                    email: "",
+                    id: -10,
+                    name: "",
+                    token: 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjotMTAsInVzZXJfZW1haWwiOiIiLCJ1c2VyX25hbWUiOiIiLCJpYXQiOjE3MzQ5MTI1MzksImV4cCI6MTczNDkxMjgzOX0.83JE_NBcgHka4tk_ROkHMq_t2WP0vw_pyZ6zwswd_ps',
+                },
+            },
+            { 
+                jwt: 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMTEiLCJ1c2VyX2VtYWlsIjoiYXNkMTIzQGFzZC5jb20iLCJ1c2VyX25hbWUiOiJhc2QxMjMiLCJzdWIiOiJhc2QxMjNAYXNkLmNvbSIsImlhdCI6MTczNDI3Mjk0MCwiZXhwIjoxNzM1NTY4OTQwfQ._9zkQ4VhvkcgriALjX0uJJsIcVT4GfELwxLB-nvTrAs',
+                expected: {
+                    email: "asd123@asd.com",
+                    id: "11",
+                    name: "asd123",
+                    token: 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMTEiLCJ1c2VyX2VtYWlsIjoiYXNkMTIzQGFzZC5jb20iLCJ1c2VyX25hbWUiOiJhc2QxMjMiLCJzdWIiOiJhc2QxMjNAYXNkLmNvbSIsImlhdCI6MTczNDI3Mjk0MCwiZXhwIjoxNzM1NTY4OTQwfQ._9zkQ4VhvkcgriALjX0uJJsIcVT4GfELwxLB-nvTrAs',
+                },
+            },
+        ];
+        jwtValidCases.forEach(({ jwt, expected }) => {
+            expect(getUserPayloadFromJwt(jwt)).toStrictEqual(expected);
+        });
+    });
+
+    
+    test('WHEN apply with invalid jwt THEN return ....', () => {
+        
+        const invalidJwtCases = [
+            { jwt: '' },
+            { jwt: null },
+            { jwt: undefined },
+            { jwt: ' ' },
+            { jwt: 'saf12asffas'},
+        ];
+        invalidJwtCases.forEach(({ jwt }) => {
+            expect(() => getUserPayloadFromJwt(jwt)).toThrowError('Invalid jwt');
+        });
+    });
+
+});

--- a/front/src/helpers/api/api-client.js
+++ b/front/src/helpers/api/api-client.js
@@ -1,23 +1,46 @@
 import { toast } from 'react-toastify';
-import {  getSessionStorage, setSessionStorage } from '#helpers/browserStorage.js';
+import { 
+  getLocalStorage, setLocalStorage, 
+  getSessionStorage, setSessionStorage 
+} from '#helpers/browserStorage.js';
 import { API_CONST } from '#statics/apiConstants.js';
+import { ERROR_MESSAGES } from '#statics/messages.js';
 
-const {INTERNAL_SESSION_ID_KEY, INTERNAL_SESSION_ID_HEADER} = API_CONST;
+const {
+  INTERNAL_SESSION_ID_KEY, 
+  INTERNAL_SESSION_ID_HEADER,
+  AUTH_HEADER,
+  AUTH_TOKEN_PREFIX,
+  STORAGE_AUTH_JWT_KEY,
+  STORAGE_AUTH_USER_KEY,
+} = API_CONST;
+
+const {
+  INVALID_AUTH_SESSION
+} = ERROR_MESSAGES;
 
 const doFetch = (method) => async (endpoint, body) => {
+  const jwtToken = getLocalStorage(STORAGE_AUTH_JWT_KEY, '') || '';
   const config = {
     method,
     headers: { 
       'content-type': 'application/json',
       [INTERNAL_SESSION_ID_HEADER]: getRequestSessionId(),
+      [AUTH_HEADER]: `${AUTH_TOKEN_PREFIX} ${jwtToken}`,
     },
     body: JSON.stringify(body),
   };
   try {
     const response = await window.fetch(`${import.meta.env.VITE_API_URL}/${endpoint}`, config);
     const jsonResponse = await response.json();
+    const resMessage = jsonResponse.message || 'Error inesperado';
     if (!response.ok) {
-      throw new Error(jsonResponse.message);
+      if(response.status === 401) {
+        resetUserSessionStorage();
+        console.error('response status 401', resMessage);
+        throw new Error(INVALID_AUTH_SESSION);
+      }
+      throw new Error(resMessage);
     }
     return jsonResponse;
   } catch (e) {
@@ -26,6 +49,11 @@ const doFetch = (method) => async (endpoint, body) => {
     toast.error(e.message, { position: toast.POSITION.TOP_CENTER });
     throw new Error(e.message);
   }
+};
+
+const resetUserSessionStorage = () => {
+  setLocalStorage(STORAGE_AUTH_USER_KEY, null);
+  setLocalStorage(STORAGE_AUTH_JWT_KEY, null);
 };
 
 const getRequestSessionId = () => {

--- a/front/src/helpers/api/user-client.js
+++ b/front/src/helpers/api/user-client.js
@@ -1,14 +1,39 @@
 import { get, post } from './api-client';
+import { setLocalStorage } from '#helpers/browserStorage.js';
+import { getUserPayloadFromJwt } from '#helpers/jwt';
+import { API_ENDPOINTS_CONST, API_CONST } from '#statics/apiConstants';
+
+const {
+  AUTH_ENDPOINT,
+} = API_ENDPOINTS_CONST;
+
+const {
+  STORAGE_AUTH_JWT_KEY
+} = API_CONST;
+
+const handleExtractUserDataFromJwtAndSaveJwt = (res) => {
+  const userPayload = getUserPayloadFromJwt(res.token);
+  setLocalStorage(STORAGE_AUTH_JWT_KEY, res.token)
+  return userPayload;
+}
+
+const handleClearUserLocalStorage = () => {
+  setLocalStorage(STORAGE_AUTH_JWT_KEY, null);
+}
 
 const identify = (email) => get(`user/identify/${email}/`).then((r) => r.data);
 
-const login = (userData) => post('user/auth', userData);
+const login = (userData) => post(`${AUTH_ENDPOINT}/login`, userData).then(handleExtractUserDataFromJwtAndSaveJwt);
 
-const register = (userData) => post('user', userData);
+const register = (userData) => post(`${AUTH_ENDPOINT}/register`, userData).then(handleExtractUserDataFromJwtAndSaveJwt);
+
+const logout = () => post(`${AUTH_ENDPOINT}/logout`).then(handleClearUserLocalStorage);
+
+const logoutAllSessions = () => post(`${AUTH_ENDPOINT}/logout/all`).then(handleClearUserLocalStorage);
 
 const sendRecoveryEmail = (email) => post(`user/recovery`, { email });
 
 const resetPassword = (email, password, token) =>
   post('user/reset', { email, password, resetToken: token });
 
-export { identify, login, register, sendRecoveryEmail, resetPassword };
+export { identify, login, register, sendRecoveryEmail, resetPassword, logout, logoutAllSessions };

--- a/front/src/helpers/jwt.js
+++ b/front/src/helpers/jwt.js
@@ -1,0 +1,23 @@
+import { jwtDecode } from "jwt-decode";
+
+export const decodeJWT = (jwtToken, defaultValue=null) => {
+    try {
+        return jwtDecode(jwtToken);
+    } catch (ex) {
+        console.error('error decoding jwt', ex);
+        return defaultValue;
+    }
+}
+
+export const getUserPayloadFromJwt = (jwt) => {
+    const jwtPayload = decodeJWT(jwt);
+    if (!jwtPayload) {
+        throw Error('Invalid jwt');
+    }
+    return {
+        id: jwtPayload.user_id,
+        email: jwtPayload.user_email,
+        name: jwtPayload.user_name,
+        token: jwt,
+    };
+};

--- a/front/src/statics/apiConstants.js
+++ b/front/src/statics/apiConstants.js
@@ -1,5 +1,13 @@
 
 export const API_CONST = {
-    INTERNAL_SESSION_ID_KEY: "internalSessionId",
+    INTERNAL_SESSION_ID_KEY: 'internalSessionId',
     INTERNAL_SESSION_ID_HEADER:'X-Internal-Session-Id',
+    AUTH_HEADER: 'Authorization',
+    AUTH_TOKEN_PREFIX: 'Bearer',
+    STORAGE_AUTH_JWT_KEY: '__smartopenspace_jwt__',
+    STORAGE_AUTH_USER_KEY: '__smartopenspace_user__',
+};
+
+export const API_ENDPOINTS_CONST = {
+    AUTH_ENDPOINT: "v1/auth",
 };

--- a/front/src/statics/messages.js
+++ b/front/src/statics/messages.js
@@ -1,0 +1,3 @@
+export const ERROR_MESSAGES = {
+    INVALID_AUTH_SESSION: 'Sesión invalida, por favor inicie sesión nuevamente',
+};


### PR DESCRIPTION
# Require
- [x] [Merge PR#369](https://github.com/10Pines/smart-open-space/pull/369)

# Tasks
- [X] Migrate front to new auth endpoints (login, register and logout).
- [X] Handling jwt in front local storage and send it always in back request. 
- [X] Fix logout and logout/all response with some json body (returning user_id of logout session/s).
- [X] Add MDC logs in back to know when jwt is sent.
- [x] Record evidence 

# Evidence

- Login con JWT:

https://github.com/user-attachments/assets/ce130856-490f-4d45-b712-699195d4257c


- Register JWT:

https://github.com/user-attachments/assets/349ee728-1146-4ab1-90fc-56d68fbfd06c



