### PR TITLE
Fix/auth session token persistence length

### DIFF
--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/AuthSession.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/AuthSession.kt
@@ -9,7 +9,7 @@ class AuthSession(
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     var id: String = "",
-    @Column(unique = true)
+    @Column(unique = true, length = 455)
     val token: String,
     val createdOn: Instant,
     val expiresOn: Instant,

--- a/back/src/main/kotlin/com/sos/smartopenspace/services/impl/AuthService.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/services/impl/AuthService.kt
@@ -97,8 +97,11 @@ class AuthService(
             revoked = false,
             user = user,
         )
-        //FIXME: Should be removed or set as DEBUG when issue is fixed
-        LOGGER.info("Creating auth session $authSession with token length ${authSession.token.length}")
+        LOGGER.debug(
+            "Creating auth session {} with token length {}",
+            authSession,
+            authSession.token.length
+        )
         return authSessionRepository.save(authSession)
     }
 

--- a/back/src/main/resources/db/migration/U1_22__extend_auth_token_column_size.sql
+++ b/back/src/main/resources/db/migration/U1_22__extend_auth_token_column_size.sql
@@ -1,1 +1,1 @@
-ALTER TABLE auth_session ALTER COLUMN token VARCHAR (255);
+ALTER TABLE auth_session ALTER COLUMN token TYPE VARCHAR(255);

--- a/back/src/main/resources/db/migration/U1_22__extend_auth_token_column_size.sql
+++ b/back/src/main/resources/db/migration/U1_22__extend_auth_token_column_size.sql
@@ -1,0 +1,1 @@
+ALTER TABLE auth_session ALTER COLUMN token VARCHAR (255);

--- a/back/src/main/resources/db/migration/V1_22__extend_auth_token_column_size.sql
+++ b/back/src/main/resources/db/migration/V1_22__extend_auth_token_column_size.sql
@@ -1,0 +1,1 @@
+ALTER TABLE auth_session ALTER COLUMN token VARCHAR (455);

--- a/back/src/main/resources/db/migration/V1_22__extend_auth_token_column_size.sql
+++ b/back/src/main/resources/db/migration/V1_22__extend_auth_token_column_size.sql
@@ -1,1 +1,1 @@
-ALTER TABLE auth_session ALTER COLUMN token VARCHAR (455);
+ALTER TABLE auth_session ALTER COLUMN token TYPE VARCHAR(455);


### PR DESCRIPTION
- Change varchar 255 to 455 (increase 200 chars).
- Add migration files.
- Set log info token length every creation entity to debug log.