### PR TITLE
fix/blackbox-back-healthcheck

### DIFF
--- a/docs/container/README.md
+++ b/docs/container/README.md
@@ -49,6 +49,8 @@ Estar en el directorio root del repositorio. Luego, ejecutar:
 cd front && docker build -t sos-front .
 ```
 
+Nota: En caso de error, borrar carpetas temporales `node_modules` y `build`.
+
 3. Revisar variables de entorno (env vars), como `APP_PORT`, `SPRING_PROFILE`, `DB_PORT`, donde van a configurarse en los contenedores en el archivo [`docker-compose.yml`](/docs/container/docker-compose.yml).
 
 4. Revisar que no tengamos una instancia local del servicio ejecutando o algun puerto ocupado de la configuración anterior. Luego, ejecutamos el comando en el directorio root del proyecto:

--- a/docs/container/prometheus/prometheus.yml
+++ b/docs/container/prometheus/prometheus.yml
@@ -41,7 +41,7 @@ scrape_configs:
       module: [ http_2xx ]
     static_configs:
       - targets:
-        - http://sos-back:8081/
+        - http://sos-back:8081/actuator/health
         - http://sos-front:1234/
     relabel_configs:
       - source_labels: [ __address__ ]


### PR DESCRIPTION
- Change blackbox health back `"/"` ping endpoint to actuator health endpoint `"/actuator/health"`

## Evidence

- Start service with new config and pause-resume (wait 5min in each action) back app-container.

- Prometheus alarm screenshot:
![prometheus_alarm](https://github.com/user-attachments/assets/9961cfb2-a34d-41c1-9492-8c70bcc283f1)
- Discord alarm screenshot:
![alarm_service_back_down](https://github.com/user-attachments/assets/ab0d09d2-0915-41c9-9770-c7fd6aac6009)

- Prometheus alarm solved screenshot:
![prometheus_alarm_ok](https://github.com/user-attachments/assets/7e8dad0b-3ac5-4bb1-8c5f-4cc2a13d86de)
- Discord alarm solved screenshot:
![resolved_alarm_service_back](https://github.com/user-attachments/assets/35d640b8-0d52-4b5b-a33a-3ae92bee6f23)

