### PR TITLE
Bump vite from 6.2.4 to 6.2.5

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -53,7 +53,7 @@
         "lint-staged": "^10.2.2",
         "prettier": "^2.0.2",
         "typescript": "^3.8.3",
-        "vite": "^6.2.4",
+        "vite": "^6.2.5",
         "vite-plugin-html": "^3.2.2",
         "vitest": "^3.0.8"
       },
@@ -8760,9 +8760,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/front/package.json
+++ b/front/package.json
@@ -53,7 +53,7 @@
     "lint-staged": "^10.2.2",
     "prettier": "^2.0.2",
     "typescript": "^3.8.3",
-    "vite": "^6.2.4",
+    "vite": "^6.2.5",
     "vite-plugin-html": "^3.2.2",
     "vitest": "^3.0.8"
   },


### PR DESCRIPTION
Bumps the npm_and_yarn group in /front with 1 update: [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite).


Updates `vite` from 6.2.4 to 6.2.5
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/v6.2.5/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v6.2.5/packages/vite)

---
updated-dependencies:
- dependency-name: vite dependency-version: 6.2.5 dependency-type: direct:development dependency-group: npm_and_yarn ...