### PR TITLE
enhancement/upgrade-spring-boot-lib

### DIFF
--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -3,7 +3,7 @@ import de.undercouch.gradle.tasks.download.Download
 plugins {
   base
   val kotlinVersion = "2.1.20"
-  id("org.springframework.boot") version "3.2.7"
+  id("org.springframework.boot") version "3.3.13"
   id("io.spring.dependency-management") version "1.1.7"
   id("org.flywaydb.flyway") version "11.0.0"
   id("de.undercouch.download") version "5.6.0"
@@ -28,6 +28,7 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
   implementation("org.flywaydb:flyway-core")
+  implementation("org.flywaydb:flyway-database-postgresql")
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   implementation("org.jetbrains.kotlin:kotlin-stdlib")
   implementation("org.springframework.boot:spring-boot-starter-aop")

--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
   runtimeOnly("com.newrelic.agent.java:newrelic-agent:8.19.0")
   runtimeOnly("io.micrometer:micrometer-registry-prometheus")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
-  testImplementation("io.mockk:mockk:1.13.17")
+  testImplementation("io.mockk:mockk:1.14.5")
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("io.micrometer:micrometer-observation-test")
 }

--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
   implementation("org.glassfish.jersey.inject:jersey-hk2")
   runtimeOnly("com.h2database:h2")
   runtimeOnly("org.postgresql:postgresql")
-  runtimeOnly("com.newrelic.agent.java:newrelic-agent:8.19.0")
+  runtimeOnly("com.newrelic.agent.java:newrelic-agent:8.23.0")
   runtimeOnly("io.micrometer:micrometer-registry-prometheus")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("io.mockk:mockk:1.14.5")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ networks:
     driver: bridge
 
 volumes:
-  sos-db-data:
+  sos-db-data-postgres17:
   sos-pgadmin-data:
   prometheus_data: {}
   grafana_data: {}
@@ -56,7 +56,7 @@ services:
       logging_jobname: "containerlogs"
 
   db:
-    image: postgres:15.0-alpine
+    image: postgres:17-alpine
     container_name: db
     restart: always
     environment:
@@ -65,7 +65,7 @@ services:
       POSTGRES_PASSWORD: openheart
       PGDATA: /var/lib/postgresql/data
     volumes:
-      - sos-db-data:/var/lib/postgresql/data
+      - sos-db-data-postgres17:/var/lib/postgresql/data
     ports:
       - "6543:5432"
     networks:


### PR DESCRIPTION
- Se upgradea la lib de spring boot 3.2 a 3.3.13 (no se pudo upgradear a 3.4.x o 3.5.x porque rompe tests)
- Se agrega lib de flyway con compatibilidad a postgres 17
- Se cambia el docker image de postgres a la version 17 (que es una de las mas recientes).
- Se upgradea libs secundarias (mockk y newrelic) 