### PR TITLE
Fix/unexpected exception errors

### DIFF
--- a/back/src/main/kotlin/com/sos/smartopenspace/controllers/ExceptionHandler.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/controllers/ExceptionHandler.kt
@@ -1,143 +1,191 @@
 package com.sos.smartopenspace.controllers
 
-import com.sos.smartopenspace.domain.*
+import com.sos.smartopenspace.domain.BadRequestException
+import com.sos.smartopenspace.domain.ForbiddenException
+import com.sos.smartopenspace.domain.NotFoundException
+import com.sos.smartopenspace.domain.UnauthorizedException
+import com.sos.smartopenspace.domain.UnprocessableEntityException
 import com.sos.smartopenspace.dto.DefaultErrorDto
 import com.sos.smartopenspace.metrics.API_ERROR_CONTEXT_FIELD
 import com.sos.smartopenspace.metrics.ObservationMetricHelper
 import io.github.resilience4j.ratelimiter.RequestNotPermitted
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.ConstraintViolationException
 import org.slf4j.LoggerFactory
+import org.springframework.beans.TypeMismatchException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.BindException
+import org.springframework.web.HttpMediaTypeNotAcceptableException
+import org.springframework.web.HttpMediaTypeNotSupportedException
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingPathVariableException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.ServletRequestBindingException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @ControllerAdvice
 class ExceptionHandler(
-    val observationMetricHelper: ObservationMetricHelper,
+  val observationMetricHelper: ObservationMetricHelper,
 ) {
 
-    companion object {
-        private const val DEFAULT_VALIDATION_ERROR = "Hay un campo invalido"
+  companion object {
+    private const val DEFAULT_VALIDATION_ERROR = "Hay un campo invalido"
 
-        private val LOGGER = LoggerFactory.getLogger(this::class.java)
+    private val LOGGER = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @ExceptionHandler(
+    BadRequestException::class,
+    HttpMessageNotReadableException::class,
+    HttpMediaTypeNotSupportedException::class,
+    HttpMediaTypeNotAcceptableException::class,
+    MissingServletRequestParameterException::class,
+    MissingPathVariableException::class,
+    ServletRequestBindingException::class,
+    ConstraintViolationException::class,
+    TypeMismatchException::class,
+    BindException::class
+  )
+  fun badRequestHandler(
+    request: HttpServletRequest,
+    ex: Exception
+  ): ResponseEntity<DefaultErrorDto> {
+    val httpStatus = HttpStatus.BAD_REQUEST
+    handleLogError(httpStatus, ex, false)
+
+    val errorDto = DefaultErrorDto(ex.message, httpStatus)
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, httpStatus)
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException::class)
+  fun badRequestValidations(
+    request: HttpServletRequest,
+    ex: MethodArgumentNotValidException
+  ): ResponseEntity<DefaultErrorDto> {
+    val httpStatus = HttpStatus.BAD_REQUEST
+    handleLogError(httpStatus, ex, false)
+    val errors = ex.bindingResult.allErrors.mapNotNull { it.defaultMessage }
+    val errorMsg = errors.getOrNull(0) ?: DEFAULT_VALIDATION_ERROR
+
+    val errorDto = DefaultErrorDto(errorMsg, httpStatus)
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, httpStatus)
+  }
+
+  @ExceptionHandler(UnprocessableEntityException::class)
+  fun unprocessableEntityHandler(
+    request: HttpServletRequest,
+    ex: Exception
+  ): ResponseEntity<DefaultErrorDto> {
+    val httpStatus = HttpStatus.UNPROCESSABLE_ENTITY
+    handleLogError(httpStatus, ex, false)
+
+    val errorDto = DefaultErrorDto(ex.message, httpStatus)
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, httpStatus)
+  }
+
+  @ExceptionHandler(NotFoundException::class)
+  fun notFoundHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
+    val httpStatus = HttpStatus.NOT_FOUND
+    handleLogError(httpStatus, ex, false)
+
+    val errorDto = DefaultErrorDto(ex.message, httpStatus)
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, httpStatus)
+  }
+
+  @ExceptionHandler(UnauthorizedException::class)
+  fun notAuthHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
+    val httpStatus = HttpStatus.UNAUTHORIZED
+    handleLogError(httpStatus, ex)
+
+    val errorDto = DefaultErrorDto(ex.message, httpStatus)
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, httpStatus)
+  }
+
+  @ExceptionHandler(ForbiddenException::class)
+  fun forbiddenHandler(
+    request: HttpServletRequest,
+    ex: Exception
+  ): ResponseEntity<DefaultErrorDto> {
+    val httpStatus = HttpStatus.FORBIDDEN
+    handleLogError(httpStatus, ex)
+
+    val errorDto = DefaultErrorDto(ex.message, httpStatus)
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, httpStatus)
+  }
+
+  @ExceptionHandler(NoResourceFoundException::class)
+  fun endpointNotFoundHandler(
+    request: HttpServletRequest,
+    ex: Exception
+  ): ResponseEntity<DefaultErrorDto> {
+    val httpStatus = HttpStatus.NOT_FOUND
+    handleLogError(httpStatus, ex)
+
+    val errorDto = DefaultErrorDto(ex.message, httpStatus)
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, httpStatus)
+  }
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+  fun methodNotAllowedHandler(
+    request: HttpServletRequest,
+    ex: Exception
+  ): ResponseEntity<DefaultErrorDto> {
+    val httpStatus = HttpStatus.METHOD_NOT_ALLOWED
+    handleLogError(httpStatus, ex)
+
+    val errorDto = DefaultErrorDto(ex.message, httpStatus)
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, httpStatus)
+  }
+
+  @ExceptionHandler(RequestNotPermitted::class)
+  fun handleRateLimiterException(
+    request: HttpServletRequest,
+    ex: RequestNotPermitted
+  ): ResponseEntity<DefaultErrorDto> {
+    val httpStatus = HttpStatus.TOO_MANY_REQUESTS
+    handleLogError(httpStatus, ex, false)
+
+    val errorDto = DefaultErrorDto("rate_limiter_too_many_request", httpStatus)
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, httpStatus)
+  }
+
+  @ExceptionHandler(Exception::class)
+  fun fallbackExceptionHandler(
+    request: HttpServletRequest,
+    ex: Exception
+  ): ResponseEntity<DefaultErrorDto> {
+    val errorDto = DefaultErrorDto(ex.message, HttpStatus.INTERNAL_SERVER_ERROR, true)
+    LOGGER.error("Handling fallback uncaught exception ${ex.javaClass} , [message=${ex.message}] and [error_dto=$errorDto]")
+    observeError(request, errorDto)
+    return ResponseEntity(errorDto, HttpStatus.INTERNAL_SERVER_ERROR)
+  }
+
+  private fun handleLogError(status: HttpStatus, ex: Exception, withStackTrace: Boolean = true) {
+    val errMsg =
+      "Handling http status ${status.name} with exception ${ex.javaClass} and message: ${ex.message}."
+    if (withStackTrace) {
+      LOGGER.error(errMsg, ex)
+    } else {
+      LOGGER.error(errMsg)
     }
+  }
 
-    @ExceptionHandler(BadRequestException::class)
-    fun badRequestHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
-        val httpStatus = HttpStatus.BAD_REQUEST
-        handleLogError(httpStatus, ex, false)
-
-        val errorDto = DefaultErrorDto(ex.message, httpStatus)
-        observeError(request, errorDto)
-        return ResponseEntity(errorDto, httpStatus)
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun badRequestValidations(request: HttpServletRequest, ex: MethodArgumentNotValidException): ResponseEntity<DefaultErrorDto> {
-        val httpStatus = HttpStatus.BAD_REQUEST
-        handleLogError(httpStatus, ex, false)
-        val errors = ex.bindingResult.allErrors.mapNotNull { it.defaultMessage }
-        val errorMsg = errors.getOrNull(0) ?: DEFAULT_VALIDATION_ERROR
-
-        val errorDto = DefaultErrorDto(errorMsg, httpStatus)
-        observeError(request, errorDto)
-        return ResponseEntity(errorDto, httpStatus)
-    }
-
-    @ExceptionHandler(UnprocessableEntityException::class)
-    fun unprocessableEntityHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
-        val httpStatus = HttpStatus.UNPROCESSABLE_ENTITY
-        handleLogError(httpStatus, ex, false)
-
-        val errorDto = DefaultErrorDto(ex.message, httpStatus)
-        observeError(request, errorDto)
-        return ResponseEntity(errorDto, httpStatus)
-    }
-
-    @ExceptionHandler(NotFoundException::class)
-    fun notFoundHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
-        val httpStatus = HttpStatus.NOT_FOUND
-        handleLogError(httpStatus, ex, false)
-
-        val errorDto = DefaultErrorDto(ex.message, httpStatus)
-        observeError(request, errorDto)
-        return ResponseEntity(errorDto, httpStatus)
-    }
-
-    @ExceptionHandler(UnauthorizedException::class)
-    fun notAuthHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
-        val httpStatus = HttpStatus.UNAUTHORIZED
-        handleLogError(httpStatus, ex)
-
-        val errorDto = DefaultErrorDto(ex.message, httpStatus)
-        observeError(request, errorDto)
-        return ResponseEntity(errorDto, httpStatus)
-    }
-
-    @ExceptionHandler(ForbiddenException::class)
-    fun forbiddenHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
-        val httpStatus = HttpStatus.FORBIDDEN
-        handleLogError(httpStatus, ex)
-
-        val errorDto = DefaultErrorDto(ex.message, httpStatus)
-        observeError(request, errorDto)
-        return ResponseEntity(errorDto, httpStatus)
-    }
-
-    @ExceptionHandler(NoResourceFoundException::class)
-    fun endpointNotFoundHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
-        val httpStatus = HttpStatus.NOT_FOUND
-        handleLogError(httpStatus, ex)
-
-        val errorDto = DefaultErrorDto(ex.message, httpStatus)
-        observeError(request, errorDto)
-        return ResponseEntity(errorDto, httpStatus)
-    }
-
-    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
-    fun methodNotAllowedHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
-        val httpStatus = HttpStatus.METHOD_NOT_ALLOWED
-        handleLogError(httpStatus, ex)
-
-        val errorDto = DefaultErrorDto(ex.message, httpStatus)
-        observeError(request, errorDto)
-        return ResponseEntity(errorDto, httpStatus)
-    }
-
-    @ExceptionHandler(RequestNotPermitted::class)
-    fun handleRateLimiterException(request: HttpServletRequest, ex: RequestNotPermitted): ResponseEntity<DefaultErrorDto> {
-        val httpStatus = HttpStatus.TOO_MANY_REQUESTS
-        handleLogError(httpStatus, ex, false)
-
-        val errorDto = DefaultErrorDto("rate_limiter_too_many_request", httpStatus)
-        observeError(request, errorDto)
-        return ResponseEntity(errorDto, httpStatus)
-    }
-
-    @ExceptionHandler(Exception::class)
-    fun fallbackExceptionHandler(request: HttpServletRequest, ex: Exception): ResponseEntity<DefaultErrorDto> {
-        val errorDto = DefaultErrorDto(ex.message, HttpStatus.INTERNAL_SERVER_ERROR, true)
-        LOGGER.error("Handling fallback uncaught exception ${ex.javaClass} , [message=${ex.message}] and [error_dto=$errorDto]")
-        observeError(request, errorDto)
-        throw ex
-    }
-
-    private fun handleLogError(status: HttpStatus, ex: Exception, withStackTrace: Boolean = true) {
-        val errMsg =
-            "Handling http status ${status.name} with exception ${ex.javaClass} and message: ${ex.message}."
-        if (withStackTrace) {
-            LOGGER.error(errMsg, ex)
-        } else {
-            LOGGER.error(errMsg)
-        }
-    }
-
-    private fun observeError(request: HttpServletRequest, errorDto: DefaultErrorDto) {
-        observationMetricHelper.addContext(request, API_ERROR_CONTEXT_FIELD, errorDto)
-    }
+  private fun observeError(request: HttpServletRequest, errorDto: DefaultErrorDto) {
+    observationMetricHelper.addContext(request, API_ERROR_CONTEXT_FIELD, errorDto)
+  }
 
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/dto/request/CreateReviewRequestDTO.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/dto/request/CreateReviewRequestDTO.kt
@@ -1,12 +1,16 @@
 package com.sos.smartopenspace.dto.request
-import jakarta.validation.constraints.*
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 
 data class CreateReviewRequestDTO(
-  @field:NotNull
-  @field:Max(5)
-  @field:Min(1)
+  @field:NotNull(message = "El puntaje debe ser entre 1 a 5")
+  @field:Max(value = 5, message = "El puntaje debe ser entre 1 a 5")
+  @field:Min(value = 1, message = "El puntaje debe ser entre 1 a 5")
   val grade: Int,
 
-  @field:Size(max = 1000)
+  @field:Size(max = 1000, message = "El comentario admite un máximo de 1000 caracteres")
   val comment: String?
 )

--- a/back/src/main/kotlin/com/sos/smartopenspace/dto/request/CreateTalkRequestDTO.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/dto/request/CreateTalkRequestDTO.kt
@@ -1,24 +1,24 @@
 package com.sos.smartopenspace.dto.request
 
 import com.sos.smartopenspace.domain.Document
-import java.net.URL
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
+import java.net.URL
 
 data class CreateTalkRequestDTO(
-    @field:NotEmpty(message = "Ingrese un nombre")
-    @field:NotBlank(message = "Nombre no puede ser vacío")
-    val name: String,
+  @field:NotEmpty(message = "Ingrese un nombre")
+  @field:NotBlank(message = "Nombre no puede ser vacío")
+  val name: String,
 
-    val description: String = "",
+  val description: String = "",
 
-    val meetingLink: URL? = null,
+  val meetingLink: URL? = null,
 
-    val trackId: Long? = null,
+  val trackId: Long? = null,
 
-    @field:Valid
-    val documents: Set<Document> = emptySet(),
+  @field:Valid
+  val documents: Set<Document> = emptySet(),
 
-    val speakerName: String? = null
+  val speakerName: String? = null
 )

--- a/back/src/main/kotlin/com/sos/smartopenspace/dto/request/OpenSpaceRequestDTO.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/dto/request/OpenSpaceRequestDTO.kt
@@ -3,40 +3,40 @@ package com.sos.smartopenspace.dto.request
 import com.sos.smartopenspace.domain.Room
 import com.sos.smartopenspace.domain.Slot
 import com.sos.smartopenspace.domain.Track
-import java.time.LocalDate
 import jakarta.persistence.Column
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
+import java.time.LocalDate
 
 data class OpenSpaceRequestDTO(
-    @field:NotEmpty(message = "Ingrese un nombre")
-    @field:NotBlank(message = "Nombre no puede ser vacío")
-    val name: String,
+  @field:NotEmpty(message = "Ingrese un nombre")
+  @field:NotBlank(message = "Nombre no puede ser vacío")
+  val name: String,
 
-    val dates:Set<LocalDate>,
+  val dates: Set<LocalDate>,
 
-    @field:Valid
-    val rooms: Set<Room>,
+  @field:Valid
+  val rooms: Set<Room>,
 
-    @field:Valid
-    val slots: Set<Slot>,
+  @field:Valid
+  val slots: Set<Slot>,
 
-    @field:Column(length = 1000)
-    @field:Size(min = 0, max = 1000)
-    val description: String = "",
+  @field:Column(length = 1000)
+  @field:Size(min = 0, max = 1000)
+  val description: String = "",
 
-    @field:Valid
-    val tracks: Set<Track> = emptySet()
-    ) {
+  @field:Valid
+  val tracks: Set<Track> = emptySet()
+) {
 
-    fun slotsWithDates(): List<Slot> {
-        return slots.flatMap {slot ->
-            dates.map { date ->
-                slot.cloneWithDate(date)
-            }
-        }
+  fun slotsWithDates(): List<Slot> {
+    return slots.flatMap { slot ->
+      dates.map { date ->
+        slot.cloneWithDate(date)
+      }
     }
+  }
 
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/dto/request/RecoveryEmailRequestDTO.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/dto/request/RecoveryEmailRequestDTO.kt
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotEmpty
 
 class RecoveryEmailRequestDTO(
-    @field:NotEmpty(message = "Ingrese un email")
-    @field:Email
-    val email: String
+  @field:NotEmpty(message = "Ingrese un email")
+  @field:Email(message = "Ingrese un email válido")
+  val email: String
 )

--- a/back/src/main/kotlin/com/sos/smartopenspace/dto/request/UserLoginRequestDTO.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/dto/request/UserLoginRequestDTO.kt
@@ -6,13 +6,13 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 
 data class UserLoginRequestDTO(
-    @field:NotEmpty(message = "Ingrese un email")
-    @field:Email
-    val email: String,
-    @field:NotEmpty(message = "Ingrese una contraseña")
-    @field:NotBlank(message = "Contraseña no puede ser vacía")
-    val password: String
+  @field:NotEmpty(message = "Ingrese un email")
+  @field:Email(message = "Ingrese un email válido")
+  val email: String,
+  @field:NotEmpty(message = "Ingrese una contraseña")
+  @field:NotBlank(message = "Contraseña no puede ser vacía")
+  val password: String
 ) {
-    override fun toString(): String =
-        toStringByReflex(this, mask = listOf("password"))
+  override fun toString(): String =
+    toStringByReflex(this, mask = listOf("password"))
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/dto/request/UserValidateTokenRequestDTO.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/dto/request/UserValidateTokenRequestDTO.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotEmpty
 
 data class UserValidateTokenRequestDTO(
   @field:NotEmpty(message = "Ingrese un email")
-  @field:Email
+  @field:Email(message = "Ingrese un email válido")
   val email: String,
 
   @field:NotEmpty(message = "Ingrese una contraseña")

--- a/back/src/test/kotlin/com/sos/smartopenspace/controllers/ExceptionHandlerTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/controllers/ExceptionHandlerTest.kt
@@ -1,0 +1,193 @@
+package com.sos.smartopenspace.controllers
+
+import com.sos.smartopenspace.aUser
+import com.sos.smartopenspace.domain.Talk
+import com.sos.smartopenspace.domain.User
+import com.sos.smartopenspace.domain.UserNotBelongToAuthToken
+import com.sos.smartopenspace.dto.DefaultErrorDto
+import com.sos.smartopenspace.services.impl.JwtService.Companion.TOKEN_PREFIX
+import jakarta.ws.rs.core.HttpHeaders
+import jakarta.ws.rs.core.MediaType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+class ExceptionHandlerTest : BaseIntegrationTest() {
+
+  @Test
+  fun `test GIVEN invalid path THEN handle 404 not found`() {
+    val res = mockMvc.perform(get("/not_exist_path"))
+
+    res.andExpect(MockMvcResultMatchers.status().isNotFound)
+
+    val resBody = readMvcResponseAndConvert<DefaultErrorDto>(res)
+
+
+    val expectedRes = DefaultErrorDto(
+      message = "No static resource not_exist_path.",
+      statusCode = HttpStatus.NOT_FOUND.value(),
+      status = HttpStatus.NOT_FOUND.name.lowercase(),
+      isFallbackError = false
+    )
+    assertEquals(expectedRes, resBody)
+  }
+
+  @Test
+  fun `test GIVEN valid path but invalid http method THEN handle 405 method_not_allowed`() {
+    val res = mockMvc.perform(get("/user/auth"))
+
+    res.andExpect(MockMvcResultMatchers.status().isMethodNotAllowed)
+
+    val resBody = readMvcResponseAndConvert<DefaultErrorDto>(res)
+
+
+    val expectedRes = DefaultErrorDto(
+      message = "Request method 'GET' is not supported",
+      statusCode = HttpStatus.METHOD_NOT_ALLOWED.value(),
+      status = HttpStatus.METHOD_NOT_ALLOWED.name.lowercase(),
+      isFallbackError = false
+    )
+    assertEquals(expectedRes, resBody)
+  }
+
+  @Test
+  fun `test GIVEN invalid path parameter type and handle some endpoint which require a long type param THEN handle 400 bad request`() {
+    val (_, aUserBearerToken) = registerAndGenerateAuthToken(aUser(userEmail = getAnyUniqueEmail()))
+
+    val res = mockMvc.perform(
+      post("/talk/sarasa/user/xD/review")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("")
+        .header(HttpHeaders.AUTHORIZATION, aUserBearerToken)
+    )
+
+    res.andExpect(MockMvcResultMatchers.status().isBadRequest)
+
+    val resBody = readMvcResponseAndConvert<DefaultErrorDto>(res)
+
+
+    val expectedRes = DefaultErrorDto(
+      message = "Method parameter 'talkID': Failed to convert value of type 'java.lang.String' to required type 'long'; For input string: \"sarasa\"",
+      statusCode = HttpStatus.BAD_REQUEST.value(),
+      status = HttpStatus.BAD_REQUEST.name.lowercase(),
+      isFallbackError = false
+    )
+    assertEquals(expectedRes, resBody)
+  }
+
+  @Test
+  fun `test GIVEN invalid contentType and handle some endpoint which require APPLICATION_JSON as contentType THEN handle 400 bad request`() {
+    val (_, aUserBearerToken) = registerAndGenerateAuthToken(aUser(userEmail = getAnyUniqueEmail()))
+
+    val res = mockMvc.perform(
+      post("/talk/12/user/5/review")
+        .contentType(MediaType.TEXT_PLAIN)
+        .content("sarasa")
+        .header(HttpHeaders.AUTHORIZATION, aUserBearerToken)
+    )
+
+    res.andExpect(MockMvcResultMatchers.status().isBadRequest)
+
+    val resBody = readMvcResponseAndConvert<DefaultErrorDto>(res)
+
+
+    val expectedRes = DefaultErrorDto(
+      message = "Content-Type 'text/plain;charset=UTF-8' is not supported",
+      statusCode = HttpStatus.BAD_REQUEST.value(),
+      status = HttpStatus.BAD_REQUEST.name.lowercase(),
+      isFallbackError = false
+    )
+    assertEquals(expectedRes, resBody)
+  }
+
+  @Test
+  fun `test GIVEN empty content json and handle some endpoint which require json THEN handle 400 bad request`() {
+    val (_, aUserBearerToken) = registerAndGenerateAuthToken(aUser(userEmail = getAnyUniqueEmail()))
+
+    val res = mockMvc.perform(
+      post("/talk/12/user/5/review")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("")
+        .header(HttpHeaders.AUTHORIZATION, aUserBearerToken)
+    )
+
+    res.andExpect(MockMvcResultMatchers.status().isBadRequest)
+
+    val resBody = readMvcResponseAndConvert<DefaultErrorDto>(res)
+
+
+    val expectedRes = DefaultErrorDto(
+      message = "Required request body is missing: public com.sos.smartopenspace.dto.response.TalkResponseDTO com.sos.smartopenspace.controllers.TalkController.reviewTalk(java.lang.String,long,long,com.sos.smartopenspace.dto.request.CreateReviewRequestDTO)",
+      statusCode = HttpStatus.BAD_REQUEST.value(),
+      status = HttpStatus.BAD_REQUEST.name.lowercase(),
+      isFallbackError = false
+    )
+    assertEquals(expectedRes, resBody)
+  }
+
+  @Test
+  fun `test GIVEN invalid json content and handle some endpoint which require valid specific json THEN handle 400 bad request`() {
+    val (_, aUserBearerToken) = registerAndGenerateAuthToken(aUser(userEmail = getAnyUniqueEmail()))
+
+    val content = """{ "key": 123 """
+    val res = mockMvc.perform(
+      post("/talk/12/user/5/review")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(content)
+        .header(HttpHeaders.AUTHORIZATION, aUserBearerToken)
+    )
+
+    res.andExpect(MockMvcResultMatchers.status().isBadRequest)
+
+    val resBody = readMvcResponseAndConvert<DefaultErrorDto>(res)
+
+
+    val expectedRes = DefaultErrorDto(
+      message = "JSON parse error: Unexpected end-of-input: expected close marker for Object (start marker at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1])",
+      statusCode = HttpStatus.BAD_REQUEST.value(),
+      status = HttpStatus.BAD_REQUEST.name.lowercase(),
+      isFallbackError = false
+    )
+    assertEquals(expectedRes, resBody)
+  }
+
+  @Test
+  fun `test GIVEN valid request but some data is broken THEN should return internal server error`() {
+    val (aUser, _) = registerAndGenerateAuthToken(aUser(userEmail = getAnyUniqueEmail()))
+    val (otherUser, otherUserBearerToken) = registerAndGenerateAuthToken(aUser(userEmail = getAnyUniqueEmail()))
+    val talk = talkRepository.save(Talk("Charla", speaker = aUser))
+    val content = """{"grade": 5,"comment": "asd1234"}"""
+    userRepo.delete(otherUser)
+
+    val res = mockMvc.perform(
+      post("/talk/${talk.id}/user/${otherUser}/review")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(content)
+        .header(HttpHeaders.AUTHORIZATION, otherUserBearerToken)
+    )
+
+    res.andExpect(MockMvcResultMatchers.status().isForbidden)
+
+    val resBody = readMvcResponseAndConvert<DefaultErrorDto>(res)
+
+
+    val expectedRes = DefaultErrorDto(
+      message = UserNotBelongToAuthToken().message,
+      statusCode = 403,
+      status = "forbidden",
+      isFallbackError = false
+    )
+    assertEquals(expectedRes, resBody)
+  }
+
+  private fun registerAndGenerateAuthToken(userToRegister: User): Pair<User, String> {
+    val token = authService.register(userToRegister).token
+    val user = userRepo.findByEmail(userToRegister.email)
+      ?: throw IllegalStateException("User not created")
+    return user to "$TOKEN_PREFIX$token"
+  }
+
+}

--- a/back/src/test/kotlin/com/sos/smartopenspace/controllers/TalkControllerTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/controllers/TalkControllerTest.kt
@@ -13,6 +13,7 @@ import com.sos.smartopenspace.domain.Talk
 import com.sos.smartopenspace.domain.TalkSlot
 import com.sos.smartopenspace.domain.TrackNotFoundException
 import com.sos.smartopenspace.domain.User
+import com.sos.smartopenspace.domain.UserNotBelongToAuthToken
 import com.sos.smartopenspace.dto.DefaultErrorDto
 import com.sos.smartopenspace.dto.request.CreateTalkRequestDTO
 import com.sos.smartopenspace.generateTalkBody
@@ -404,28 +405,30 @@ class TalkControllerTest : BaseIntegrationTest() {
   }
 
   @Test
-  fun `review talk with userID not exist should not add a review`() {
-    val (aUser, aUserBearerToken) = registerAndGenerateAuthToken(aUser(userEmail = "user@gmail.com"))
+  fun `review talk with userID not exist with access token stolen should not add a review and throws UserNotBelongToAuthToken`() {
+    val (aUser, aUserBearerToken) = registerAndGenerateAuthToken(aUser(userEmail = getAnyUniqueEmail()))
     val talk = anySavedTalk(aUser)
     val content = aReviewCreationBody(5, "a review")
 
     val res = mockMvc.perform(
-      post("/talk/${talk.id}/user/999999/review")
+      post("/talk/${talk.id}/user/9999/review")
         .contentType(MediaType.APPLICATION_JSON)
         .content(content)
         .header(HttpHeaders.AUTHORIZATION, aUserBearerToken)
     )
 
     res.andExpect(MockMvcResultMatchers.status().isForbidden)
-    /*
+
     val resBody = readMvcResponseAndConvert<DefaultErrorDto>(res)
+
+
     val expectedRes = DefaultErrorDto(
-      message = UserNotFoundException().message,
-      statusCode = 404,
-      status = "not_found",
+      message = UserNotBelongToAuthToken().message,
+      statusCode = 403,
+      status = "forbidden",
       isFallbackError = false
     )
-    assertEquals(expectedRes, resBody)*/
+    assertEquals(expectedRes, resBody)
   }
 
   @Test

--- a/back/src/test/kotlin/com/sos/smartopenspace/controllers/TestErrorController.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/controllers/TestErrorController.kt
@@ -1,0 +1,18 @@
+package com.sos.smartopenspace.controllers
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/test")
+class TestController {
+
+  /**
+   * This endpoint is for test purpose
+   */
+  @GetMapping("/internal_server_error")
+  fun errorFallback(): String {
+    throw IllegalArgumentException("test error fallback")
+  }
+}


### PR DESCRIPTION
- Se arreglan errores de mapeo de respuesta de excepciones inesperadas (a status 500). Antes se mapeaba todo a 200 por un mal manejo de excepciones internas con el filtro del jwt token.
- Se agregan tests para el exception handler para verificar que cada caso se mapee correctamente a su status code.



## Evidencia

Ejemplo de caso:

1. Se fuerza una exception inesperada en JwtAuthFilter:
```kotlin
@Component
class JwtAuthFilter(
    private val jwtService: JwtService,
    private val authSessionRepository: AuthSessionRepository,
    private val handlerExceptionResolver: HandlerExceptionResolver,
    private val userDetailsService: UserDetailsService,
) : OncePerRequestFilter() {

    override fun shouldNotFilter(request: HttpServletRequest): Boolean =
        isPublicEndpoint(request)

    override fun doFilterInternal(
        request: HttpServletRequest,
        response: HttpServletResponse,
        filterChain: FilterChain
    ) {
        val now = getNowUTC()
        try {
            throw IllegalArgumentException("prueba error inesperado")
            ....
```
2. ExceptionHandler sin el return 
```kotlin
  @ExceptionHandler(Exception::class)
  fun fallbackExceptionHandler(
    request: HttpServletRequest,
    ex: Exception
  ): ResponseEntity<DefaultErrorDto> {
    val errorDto = DefaultErrorDto(ex.message, HttpStatus.INTERNAL_SERVER_ERROR, true)
    LOGGER.error("Handling fallback uncaught exception ${ex.javaClass} , [message=${ex.message}] and [error_dto=$errorDto]")
    observeError(request, errorDto)
    throw ex
  }
````


2. Evidencia con curl en endpoint securizado (dejar reseña)

```bash
curl --location --request POST 'http://localhost:8081/talk/1/user/12/review'
```

3. Respuesta:
<img width="1724" height="391" alt="image" src="https://github.com/user-attachments/assets/cab4bf73-e1ee-4ce2-b0bd-a3275df128e1" />


4. Se cambia el throw por un return del exception con el dto de error esperado
```kotlin
  @ExceptionHandler(Exception::class)
  fun fallbackExceptionHandler(
    request: HttpServletRequest,
    ex: Exception
  ): ResponseEntity<DefaultErrorDto> {
    val errorDto = DefaultErrorDto(ex.message, HttpStatus.INTERNAL_SERVER_ERROR, true)
    LOGGER.error("Handling fallback uncaught exception ${ex.javaClass} , [message=${ex.message}] and [error_dto=$errorDto]")
    observeError(request, errorDto)
    return ResponseEntity(errorDto, HttpStatus.INTERNAL_SERVER_ERROR)
  }
````


5. Respuesta al mismo curl con el cambio:
<img width="1729" height="480" alt="image" src="https://github.com/user-attachments/assets/1cc9ac18-5136-40e6-8ac1-3df0d1db501d" />





