### PR TITLE
enhancement/logs-n-auth-socket-endpoints

### DIFF
--- a/back/src/main/kotlin/com/sos/smartopenspace/config/PublicEndpointsConfig.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/config/PublicEndpointsConfig.kt
@@ -8,6 +8,8 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 const val ANY_HTTP_METHOD = "ANY"
 val PUBLIC_ENDPOINTS: Map<String, List<AntPathRequestMatcher>> = mapOf(
   ANY_HTTP_METHOD to listOf(
+    AntPathRequestMatcher("/scheduleSocket/**"),
+    AntPathRequestMatcher("/queueSocket/**"),
     AntPathRequestMatcher("/v1/auth/**"),
     AntPathRequestMatcher("/user/**"),
     AntPathRequestMatcher("/actuator/health"),

--- a/back/src/main/resources/logback-spring-docker.xml
+++ b/back/src/main/resources/logback-spring-docker.xml
@@ -13,7 +13,7 @@
   <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
       <layout class="ch.qos.logback.classic.PatternLayout">
-        <Pattern>%date{yyyy-MM-dd HH:mm:ss.SSZ} [LEVEL:%clr(%level)] [THREAD:%clr(%thread){magenta}] [SESSION_ID:%clr(%mdc{requestSessionId:-none}){blue}] [REQUEST_ID:%clr(%mdc{requestId:-none}){blue}] [REQUEST_WITH_JWT:%clr(%mdc{requestContainsJwt:-none}){blue}] %clr(%logger{3}){cyan}: %msg %ex %n</Pattern>
+        <Pattern>%date{yyyy-MM-dd HH:mm:ss.SSZ} [LEVEL:%clr(%level)] [THREAD:%clr(%thread){magenta}] [SESSION_ID:%clr(%mdc{requestSessionId:-none}){blue}] [REQUEST_ID:%clr(%mdc{requestId:-none}){blue}] [REQUEST_WITH_JWT:%clr(%mdc{requestContainsJwt:-none}){blue}] %clr(%logger{3}){cyan}: %msg %ex{5} %n</Pattern>
       </layout>
     </encoder>
   </appender>

--- a/back/src/main/resources/logback-spring.xml
+++ b/back/src/main/resources/logback-spring.xml
@@ -13,7 +13,7 @@
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <Pattern>%date{yyyy-MM-dd HH:mm:ss.SSZ} [LEVEL:%clr(%level)] [THREAD:%clr(%thread){magenta}] [SESSION_ID:%clr(%mdc{requestSessionId:-none}){blue}] [REQUEST_ID:%clr(%mdc{requestId:-none}){blue}] [REQUEST_WITH_JWT:%clr(%mdc{requestContainsJwt:-none}){blue}] %clr(%logger{3}){cyan}: %msg %ex %n</Pattern>
+                <Pattern>%date{yyyy-MM-dd HH:mm:ss.SSZ} [LEVEL:%clr(%level)] [THREAD:%clr(%thread){magenta}] [SESSION_ID:%clr(%mdc{requestSessionId:-none}){blue}] [REQUEST_ID:%clr(%mdc{requestId:-none}){blue}] [REQUEST_WITH_JWT:%clr(%mdc{requestContainsJwt:-none}){blue}] %clr(%logger{3}){cyan}: %msg %ex{5} %n</Pattern>
             </layout>
         </encoder>
     </appender>


### PR DESCRIPTION
- Se agregan mejoras de logs en los exception handlers (mejor formato y info de request que se esta manejando).
- Se reducen las lineas de stack trace de los logs. 
- Se hace publico los socket endpoints con todos los http methods (soportar POST /xhr_streaming de JS socket lib) 

Link de alarma de slack: https://10pines.slack.com/archives/C06U08HSP1D/p1760571855632849
<img width="568" height="1123" alt="image" src="https://github.com/user-attachments/assets/9e66c926-26e8-4cdc-a4f4-a257c2cf622e" />


Captura del error en NewRelic que se rechaza el endpoint, en caso que el browser no soporte websockets:
<img width="2346" height="768" alt="image" src="https://github.com/user-attachments/assets/3851e6ff-7c69-472f-9857-dcaf01e3b0e3" />
