### PR TITLE
ci: agregar timeout-minutes a workflows sin límite configurado

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -16,8 +16,9 @@ jobs:
     if: ${{ vars.IS_ENABLE_KAMAL_CD_BACK == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     defaults:
       run:
-        working-directory: back    
+        working-directory: back
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       DOCKER_BUILDKIT: 1
       KAMAL_REGISTRY_USERNAME: ${{ secrets.KAMAL_REGISTRY_USERNAME }}
@@ -68,8 +69,9 @@ jobs:
     needs: [deploy_back]
     defaults:
       run:
-        working-directory: front    
+        working-directory: front
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       DOCKER_BUILDKIT: 1
       KAMAL_REGISTRY_USERNAME: ${{ secrets.KAMAL_REGISTRY_USERNAME }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -12,6 +12,7 @@ jobs:
       run:
         working-directory: back
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         java-version: [21]

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -12,6 +12,7 @@ jobs:
       run:
         working-directory: front
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [18.x, 22.x, 24.x]

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/kamal-back-command.yml
+++ b/.github/workflows/kamal-back-command.yml
@@ -17,6 +17,7 @@ jobs:
       run:
         working-directory: back
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     env:
       KAMAL_REGISTRY_USERNAME: ${{ secrets.KAMAL_REGISTRY_USERNAME }}

--- a/.github/workflows/kamal-front-command.yml
+++ b/.github/workflows/kamal-front-command.yml
@@ -17,6 +17,7 @@ jobs:
       run:
         working-directory: front
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     env:
       KAMAL_REGISTRY_USERNAME: ${{ secrets.KAMAL_REGISTRY_USERNAME }}


### PR DESCRIPTION
## Resumen
- Agrega `timeout-minutes: 20` a `deploy_back` y `deploy_front` en `cd-app.yml` (build de Docker + deploy por SSH vía Kamal, lo más pesado del set).
- Agrega `timeout-minutes: 15` a `ci-backend.yml` (Gradle test + Sonar).
- Agrega `timeout-minutes: 10` a `ci-frontend.yml` (matrix de 3 versiones de Node, cada job es liviano).
- Agrega `timeout-minutes: 20` a `claude.yml`.
- Agrega `timeout-minutes: 20` a `kamal-back-command.yml` y `kamal-front-command.yml` (dispatch manual, el comando podría ser un deploy).
- De paso se quitaron espacios finales que quedaron en dos líneas de `cd-app.yml` al tocarlas.

## Por qué
Ninguno de los workflows tenía timeout configurado; sin él, un job colgado puede correr hasta el default de 360 min de GitHub Actions.