### PR TITLE
fix: mejorar mensaje en Mis Charlas cuando no hay charlas cargadas

### DIFF
--- a/front/src/App/MyTalks/EmptyTalk.jsx
+++ b/front/src/App/MyTalks/EmptyTalk.jsx
@@ -5,14 +5,29 @@ import PropTypes from 'prop-types';
 import takingNotesImg from '#assets/taking_notes.svg';
 import EmptyData from '#shared/EmptyData';
 
-const EmptyTalk = ({ onClick }) => (
-  <EmptyData
-    buttonText="Cargar charla"
-    img={takingNotesImg}
-    onClick={onClick}
-    text="Cargá tu charla para este Open Space"
-  />
-);
-EmptyTalk.propTypes = { onClick: PropTypes.func.isRequired };
+const EmptyTalk = ({ canAddTalk = true, onClick }) => {
+  if (!canAddTalk) {
+    return (
+      <EmptyData
+        img={takingNotesImg}
+        text="No tienes charlas cargadas para este evento"
+      />
+    );
+  }
+
+  return (
+    <EmptyData
+      buttonText="Cargar charla"
+      img={takingNotesImg}
+      onClick={onClick}
+      text="Cargá tu charla para este Open Space"
+    />
+  );
+};
+
+EmptyTalk.propTypes = {
+  canAddTalk: PropTypes.bool,
+  onClick: PropTypes.func,
+};
 
 export default EmptyTalk;

--- a/front/src/App/MyTalks/MyTalks.jsx
+++ b/front/src/App/MyTalks/MyTalks.jsx
@@ -183,8 +183,6 @@ const MyTalks = () => {
     openSpace &&
     (currentUserIsOrganizer || (isActiveCallForPapers && !openSpace.finishedQueue));
   const hasTalks = allTalks && currentUserTalks && talks.length > 0;
-  const shouldDisplayEmptyTalkButton = !hasTalks && canAddTalk;
-
   const shouldDisplayAddTalkButton = hasTalks && canAddTalk;
   const roomsWithFreeSlots = getRoomsWithSlots(openSpace.freeSlots);
   const roomsWithAssignableSlots = getRoomsWithSlots(openSpace.assignableSlots);
@@ -221,7 +219,7 @@ const MyTalks = () => {
       {!queue || (!hasTalks && isPending) ? (
         <Spinner />
       ) : !hasTalks ? (
-        shouldDisplayEmptyTalkButton && <EmptyTalk onClick={pushToNewTalk} />
+        <EmptyTalk canAddTalk={canAddTalk} onClick={pushToNewTalk} />
       ) : (
         <>
           {queue.length > 0 && myEnqueuedTalk() && (
@@ -262,9 +260,6 @@ const MyTalks = () => {
             </MyGrid>
           )}
         </>
-      )}
-      {!isActiveCallForPapers && (
-        <Detail text={'La convocatoria a propuestas se encuentra cerrada'} />
       )}
     </>
   );

--- a/front/src/__tests__/components/EmptyTalk.test.jsx
+++ b/front/src/__tests__/components/EmptyTalk.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import EmptyTalk from '../../App/MyTalks/EmptyTalk';
+
+// Mock grommet components
+vi.mock('grommet', async () => {
+  const actual = await vi.importActual('grommet');
+  return {
+    ...actual,
+    Box: vi.fn((props) => <div {...props}>{props.children}</div>),
+    Button: vi.fn(({ label, onClick, primary: _primary, ...props }) => (
+      <button onClick={onClick} {...props}>
+        {label}
+      </button>
+    )),
+    Image: vi.fn((props) => <img alt="empty" {...props} />),
+    Paragraph: vi.fn(({ textAlign: _textAlign, ...props }) => <p {...props}>{props.children}</p>),
+  };
+});
+
+describe('EmptyTalk Component', () => {
+  it('should render call to action and button when canAddTalk is true', () => {
+    const handleClick = vi.fn();
+    render(<EmptyTalk canAddTalk={true} onClick={handleClick} />);
+
+    expect(screen.getByText('Cargá tu charla para este Open Space')).toBeDefined();
+    const button = screen.getByRole('button', { name: 'Cargar charla' });
+    expect(button).toBeDefined();
+
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render misleading-free message and no button when canAddTalk is false', () => {
+    render(<EmptyTalk canAddTalk={false} />);
+
+    expect(
+      screen.getByText('No tienes charlas cargadas para este evento')
+    ).toBeDefined();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #503

### Descripción
Corrige el mensaje en la sección "Mis Charlas" cuando un usuario no tiene charlas asociadas.

- Cuando la convocatoria a propuestas no permite cargar charlas (`canAddTalk = false`), se muestra el mensaje claro: *"No tienes charlas cargadas para este evento"* sin botón de acción.
- Cuando sí se permite cargar charlas (`canAddTalk = true`), se muestra *"Cargá tu charla para este Open Space"* junto con el botón *"Cargar charla"*.
- Se elimina el mensaje redundante/confuso *"La convocatoria a propuestas se encuentra cerrada"* que aparecía al pie de la vista.
- Se agregan tests unitarios para `EmptyTalk`.